### PR TITLE
fix `g:DirDiffForceLang`

### DIFF
--- a/plugin/dirdiff.vim
+++ b/plugin/dirdiff.vim
@@ -83,7 +83,7 @@ if !exists("g:DirDiffForceLang")
 endif
 
 let g:DirDiffLangString = ""
-if (g:DirDiffForceLang == "")
+if (g:DirDiffForceLang != "")
     let g:DirDiffLangString = 'LANG=' . g:DirDiffForceLang . ' '
 endif
 


### PR DESCRIPTION
`g:DirDiffLangString` should be set ***unless*** `g:DirDiffForceLang` is empty.