### PR TITLE
Cannot reload plugin at runtime without mapping warnings

### DIFF
--- a/plugin/dirdiff.vim
+++ b/plugin/dirdiff.vim
@@ -26,10 +26,10 @@ if !exists("g:DirDiffEnableMappings")
 endif
 
 if g:DirDiffEnableMappings
-    nnoremap <unique> <Leader>dg :diffget<CR>
-    nnoremap <unique> <Leader>dp :diffput<CR>
-    nnoremap <unique> <Leader>dj :DirDiffNext<CR>
-    nnoremap <unique> <Leader>dk :DirDiffPrev<CR>
+    nnoremap <Leader>dg :diffget<CR>
+    nnoremap <Leader>dp :diffput<CR>
+    nnoremap <Leader>dj :DirDiffNext<CR>
+    nnoremap <Leader>dk :DirDiffPrev<CR>
 endif
 
 " Global Maps:


### PR DESCRIPTION
For example Vundle automatically reloads the plugin on update. If `g:DirDiffEnableMappings` is true, then the mappings get run for a second time. The `<unique>` in these mappings then throws a warning.

It seems most other plugins don't bother to use `<unique>`, and we have mappings disabled by default, unless the user wishes to enable them. At that point I believe it is likely safe to override any previous mappings they have.