### PR TITLE
Execute redraw after syncing files

### DIFF
--- a/plugin/dirdiff.vim
+++ b/plugin/dirdiff.vim
@@ -624,6 +624,7 @@ function! <SID>DirDiffSync() range
             let currLine = currLine + 1
         endif
     endwhile
+    redraw!
     echo syncCount . " diff item(s) synchronized."
 endfunction
 


### PR DESCRIPTION
Screen gets messed up after syncing files, executing a redraw ensures
screen is rendered correctly again.

Fixes will133/vim-dirdiff#11