### PR TITLE
support ignoreFileNameCase

### DIFF
--- a/doc/dirdiff.txt
+++ b/doc/dirdiff.txt
@@ -114,6 +114,9 @@ Default to do nothing: >
 
     let g:DirDiffEnableMappings = 0
 <
+Ignore FileName case during diff: >
+    let g:DirDiffIgnoreFileNameCase = 0
+
 Sets default exclude pattern: >
 
     let g:DirDiffExcludes = "CVS,*.class,*.exe,.*.swp"

--- a/plugin/dirdiff.vim
+++ b/plugin/dirdiff.vim
@@ -76,6 +76,10 @@ if !exists("g:DirDiffDynamicDiffText")
     let g:DirDiffDynamicDiffText = 0
 endif
 
+if !exists("g:DirDiffIgnoreFileNameCase")
+    let g:DirDiffIgnoreFileNameCase = 0
+endif
+
 " Force set the LANG variable before running the C command.  Default to C.
 " Set to "" to not set the variable.
 if !exists("g:DirDiffForceLang")
@@ -191,6 +195,10 @@ function! <SID>DirDiff(srcA, srcB)
     let langStr = ""
     let cmd = "!" . g:DirDiffLangString . "diff"
     let cmdarg = " -r --brief"
+
+    if (g:DirDiffIgnoreFileNameCase)
+	let cmdarg = cmdarg." --ignore-file-name-case"
+    endif
 
     " If variable is set, we ignore the case
     if (g:DirDiffIgnoreCase)


### PR DESCRIPTION
For windows platform, if there is a file called a.txt while another file called A.txt, it will consider these two files are different and will not compare these two.
So to solve these issue and an option called FileNameIgnoreCase to mitigate.