### PR TITLE
avoid redundant plugin load

### DIFF
--- a/plugin/dirdiff.vim
+++ b/plugin/dirdiff.vim
@@ -6,6 +6,11 @@
 " (C) 2001-2015 by William Lee, <wl1012@yahoo.com>
 " }}}
 
+if exists('g:loaded_dirdiff')
+  finish
+endif
+let g:loaded_dirdiff = 1
+
 " Public Interface:
 command! -nargs=* -complete=dir DirDiff call <SID>DirDiff (<f-args>)
 command! -nargs=0 DirDiffOpen call <SID>DirDiffOpen ()


### PR DESCRIPTION
This is a standard convention in Vim plugins.
It helps performance and avoids unexpected behavior.