### PR TITLE
Added DirDiffAddArgs documentation

### DIFF
--- a/doc/dirdiff.txt
+++ b/doc/dirdiff.txt
@@ -115,6 +115,7 @@ Default to do nothing: >
     let g:DirDiffEnableMappings = 0
 <
 Ignore FileName case during diff: >
+
     let g:DirDiffIgnoreFileNameCase = 0
 
 Sets default exclude pattern: >
@@ -175,6 +176,12 @@ To specify a valid theme (e.g. github): >
 To use [ and ] rather than [c and ]c motions: >
 
     let g:DirDiffSimpleMap = 1
+
+Add extra options to the "diff" tool. For example, use "-w" to ignore white
+spaces or "-N" to list all new files even when inside a new folder (instead of
+just listing the new folder name)
+
+    let g:DirDiffAddArgs = "-w"
 
 OPTIONS EXAMPLE                                 *dirdiff-options-example*
 


### PR DESCRIPTION
The "DirDiffAddArgs" was referenced in the documentation but not properly documented.

I also took this chance to suggest using this option with "-N", which let's you see all the new files (and not just the name of the new folder where they are contained).

Example where the "qa" folder contains two files that have been deleted:

* Without "-N":
![Screenshot from 2020-01-23 23-21-43](https://user-images.githubusercontent.com/42691086/73029361-ade7e280-3e37-11ea-8502-7f9fc1a3c1f4.png)

* With "-N":
![Screenshot from 2020-01-23 23-22-09](https://user-images.githubusercontent.com/42691086/73029382-b4765a00-3e37-11ea-8f37-8db7fa672848.png)

