### PR TITLE
Keep same focused vim window after DirDiffNext/DirDiffPrev.

### DIFF
--- a/plugin/dirdiff.vim
+++ b/plugin/dirdiff.vim
@@ -639,6 +639,7 @@ function! <SID>GetBaseDir(diffName)
 endfunction
 
 function! <SID>DirDiffNext()
+    let t_winid = win_getid()
     " If the current window is a diff, go down one
     call <SID>GotoDiffWindow()
     " if the current line is <= 6, (within the header range), we go to the
@@ -649,13 +650,16 @@ function! <SID>DirDiffNext()
     endif
     silent! exe (b:currentDiff + 1)
     call <SID>DirDiffOpen()
+    call win_gotoid(t_winid)
 endfunction
 
 function! <SID>DirDiffPrev()
+    let t_winid = win_getid()
     " If the current window is a diff, go down one
     call <SID>GotoDiffWindow()
     silent! exe (b:currentDiff - 1)
     call <SID>DirDiffOpen()
+    call win_gotoid(t_winid)
 endfunction
 
 " For each line, we can perform a recursive copy or delete to sync up the


### PR DESCRIPTION
I moved to the latest `vim-dirdiff` so I could specify bindings from `vimrc`. But I found that focus changed after Next/Prev. This patch restores the earlier behavior; don't know when/how it was lost.