### PR TITLE
Fix plugin loses track of current state

### DIFF
--- a/plugin/dirdiff.vim
+++ b/plugin/dirdiff.vim
@@ -470,6 +470,17 @@ function! <SID>DirDiffOpen()
         return
     endif
 
+    let line = getline(".")
+    let mode = 0
+    if <SID>IsDiffer(line)
+      let mode = 2
+    elseif <SID>IsOnly(line)
+      let mode = 1
+    else
+        echo "There is no diff at the current line! "
+        return
+    endif
+
     " First dehighlight the last marked line
     call <SID>DeHighlightLine()
 
@@ -479,7 +490,6 @@ function! <SID>DirDiffOpen()
     " Change back to the right window
     call <SID>GotoDiffWindow()
 
-    let line = getline(".")
     let b:currentDiff = line(".")
 
     let previousFileA = exists("s:FilenameA") ? s:FilenameA : ""
@@ -492,7 +502,7 @@ function! <SID>DirDiffOpen()
     let s:FilenameA = <SID>EscapeFileName(fileA)
     let s:FilenameB = <SID>EscapeFileName(fileB)
 
-    if <SID>IsOnly(line)
+    if mode == 1
         " We open the file
         let fileSrc = <SID>ParseOnlySrc(line)
         if (fileSrc == "A")
@@ -524,8 +534,7 @@ function! <SID>DirDiffOpen()
         exe("resize " . g:DirDiffWindowSize)
         exe (b:currentDiff)
         let s:LastMode = fileSrc
-    elseif <SID>IsDiffer(line)
-
+    elseif mode == 2
         if exists("s:LastMode")
             if s:LastMode == 2
                 call <SID>Drop(previousFileA)
@@ -564,7 +573,7 @@ function! <SID>DirDiffOpen()
         exe ("normal z.")
         let s:LastMode = 2
     else
-        echo "There is no diff at the current line!"
+        echo "should not happen"
     endif
 endfunction
 


### PR DESCRIPTION
To fix the following scenario:

1- diff 2 directories
2- open a `differ` 
3- `Enter`/`o` outside of the `differ` or `only in` range (e.g., on any of the 6 first lines)
4- open again the same `differ` line as in 2-

(Neovim 0.10.4 on MacOS)


=> The diff state is then broken:
- the ex command line height is now weirdly increased (I havent tracked why)
- it's now basically impossible to reenter a stable state, by opening a new `differ` or `only in` line


It seems to me that in the function `DirDiffOpen()`, we try too late to manage the case where we hit a non diff/only line.

After 3-:
- `b:currentDiff` refers to the new non-diff line
- `s:FilenameA` and `s:FilenameB` now contain the names of directories `[A]` and `[B]` respectively.

On 4-, when we enter `DirDiffOpen()` again, we [don't exit the function right away](https://github.com/will133/vim-dirdiff/blob/master/plugin/dirdiff.vim#L469) because `b:currentDiff` does not match. Why not.

However, [when we finally enter this block](https://github.com/will133/vim-dirdiff/blob/master/plugin/dirdiff.vim#L531-L539),  [the call to `bufnr(directory A)`](https://github.com/will133/vim-dirdiff/blob/master/plugin/dirdiff.vim#L534) returns the same buffer number as that of the actual file A in diff. So, we basically delete the buffer we just entered.


I think that the easiest is, during step 3, leave things as immaculate as possible:
like, if we see that we are not on a `differ` or `only` line, we just leave, which is what I propose in this PR.

